### PR TITLE
Zeek v4.1 compatibility

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,13 +1,13 @@
 
 cmake_minimum_required(VERSION 2.8)
 
-project(BroPluginGQUIC)
+project(ZeekPluginGQUIC)
 
-include(BroPlugin)
+include(ZeekPlugin)
 
-bro_plugin_begin(Salesforce GQUIC)
-bro_plugin_cc(src/GQUIC.cc src/Plugin.cc)
-bro_plugin_bif(src/events.bif src/consts.bif src/types.bif)
-bro_plugin_pac(src/gquic.pac src/gquic-protocol.pac src/gquic-analyzer.pac)
-bro_plugin_dist_files(README CHANGES COPYING VERSION)
-bro_plugin_end()
+zeek_plugin_begin(Salesforce GQUIC)
+zeek_plugin_cc(src/GQUIC.cc src/Plugin.cc)
+zeek_plugin_bif(src/events.bif src/consts.bif src/types.bif)
+zeek_plugin_pac(src/gquic.pac src/gquic-protocol.pac src/gquic-analyzer.pac)
+zeek_plugin_dist_files(README CHANGES COPYING VERSION)
+zeek_plugin_end()

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,2 @@
+# Comment line immediately above ownership line is reserved for related gus information. Please be careful while editing.
+#ECCN:Open Source

--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ Created by:
 With assistance from:
 * [John Althouse](https://twitter.com/4A4133)
 * [Rakesh Passa](https://twitter.com/Sithari443)
-* The [Corelight Team](https://github.com/corelight/zeek-quic)
+* The [Corelight Team](https://github.com/corelight/bro-quic)
 * Salesforce Threat Detection Team
 
 ### References:

--- a/README.md
+++ b/README.md
@@ -1,21 +1,16 @@
 # GQUIC Protocol Analyzer
-This analyzer parses GQUIC traffic in Bro/Zeek for logging and detection purposes.  It examines the initial exchange between a client and server communicating over GQUIC, and extracts the information contained in the connection's client hello packet and  server rejection packet.  Currently, this protocol analyzer supports GQUIC versions Q039 to Q046.
+This analyzer parses GQUIC traffic in Zeek for logging and detection purposes.  It examines the initial exchange between a client and server communicating over GQUIC, and extracts the information contained in the connection's client hello packet and  server rejection packet.  Currently, this protocol analyzer supports GQUIC versions Q039 to Q046.
 
 ## Installing the GQUIC Protocol Analyzer using Source Tree
 
 ##### For a standard installation
 
  ```sh
-./configure --bro-dist=/path/to/bro/dist
+./configure --zeek-dist=/path/to/zeek/dist
 make
 make install
 ```
 
-##### To test before installation
-```sh
-export BRO_PLUGIN_PATH=/path/to/bro-quic/build
-bro -N
-```
 ##### To see all options, including setting the install path, run:
  ```sh
 ./configure --help
@@ -67,7 +62,7 @@ Generated whenever a rejection packet (server hello) is detected in GQUIC traffi
 * **rej**: A data type which contains the information about the tags of a server rejection packet.
 
 ## New Constants
-Defined in the init.bro script, a constant named `skip_after_confirm` is set to true.  This means that only the initial exchange between the client and server will be captured.  This is done to reduce noise, but it also reduces some visibility.  It can be set to true as one sees fit.
+Defined in the init.zeek script, a constant named `skip_after_confirm` is set to true.  This means that only the initial exchange between the client and server will be captured.  This is done to reduce noise, but it also reduces some visibility.  It can be set to true as one sees fit.
 
 ## New Types Created
 The GQUIC protocol analyzer adds three new data types which can be referenced in Zeek scripts.
@@ -201,7 +196,7 @@ Created by:
 With assistance from:
 * [John Althouse](https://twitter.com/4A4133)
 * [Rakesh Passa](https://twitter.com/Sithari443)
-* The [Corelight Team](https://github.com/corelight/bro-quic)
+* The [Corelight Team](https://github.com/corelight/zeek-quic)
 * Salesforce Threat Detection Team
 
 ### References:

--- a/bro-pkg.meta
+++ b/bro-pkg.meta
@@ -1,5 +1,0 @@
-[package]
-description = Protocol analyzer that detects, dissects, fingerprints, and logs GQUIC traffic
-plugin_dir = build/Salesforce_GQUIC.tgz
-script_dir = scripts/Salesforce/GQUIC
-build_command = test -e %(bro_dist)s/bro-path-dev.in && ( ./configure --bro-dist=%(bro_dist)s && make ) || ( ./configure && make )

--- a/configure
+++ b/configure
@@ -14,22 +14,14 @@ if [ -e `dirname $0`/configure.plugin ]; then
     . `dirname $0`/configure.plugin
 fi
 
-# Check for `cmake` command.
-type cmake > /dev/null 2>&1 || {
-    echo "\
-This package requires CMake, please install it first, then you may
-use this configure script to access CMake equivalent functionality.\
-" >&2;
-    exit 1;
-}
-
 usage() {
 
 cat 1>&2 <<EOF
 Usage: $0 [OPTIONS]
 
   Plugin Options:
-    --bro-dist=DIR             Path to Bro source tree
+    --cmake=PATH               Path to CMake binary
+    --zeek-dist=DIR            Path to Zeek source tree
     --install-root=DIR         Path where to install plugin into
     --with-binpac=DIR          Path to BinPAC installation root
     --with-broker=DIR          Path to Broker installation root
@@ -58,7 +50,7 @@ append_cache_entry () {
 
 # set defaults
 builddir=build
-brodist=""
+zeekdist=""
 installroot="default"
 CMakeCacheEntries=""
 
@@ -73,8 +65,16 @@ while [ $# -ne 0 ]; do
             usage
             ;;
 
-        --bro-dist=*)
-            brodist=`cd $optarg && pwd`
+        --cmake=*)
+            CMakeCommand=$optarg
+            ;;
+
+        --zeek-dist=*)
+            zeekdist=`cd $optarg && pwd`
+            ;;
+
+        --bro-dist=*) # Legacy option for backwards compability
+            zeekdist=`cd $optarg && pwd`
             ;;
 
         --install-root=*)
@@ -116,56 +116,81 @@ while [ $# -ne 0 ]; do
     shift
 done
 
-if [ -z "$brodist" ]; then
-    if type bro-config >/dev/null 2>&1; then
-        if bro-config --cmake_dir >/dev/null 2>&1; then
-            # Have a newer version of bro-config that has needed flags
-            append_cache_entry BRO_CONFIG_PREFIX PATH `bro-config --prefix`
-            append_cache_entry BRO_CONFIG_INCLUDE_DIR PATH `bro-config --include_dir`
-            append_cache_entry BRO_CONFIG_PLUGIN_DIR PATH `bro-config --plugin_dir`
-            append_cache_entry BRO_CONFIG_CMAKE_DIR PATH `bro-config --cmake_dir`
-            append_cache_entry CMAKE_MODULE_PATH PATH `bro-config --cmake_dir`
+if [ -z "$CMakeCommand" ]; then
+    # prefer cmake3 over "regular" cmake (cmake == cmake2 on RHEL)
+    if command -v cmake3 >/dev/null 2>&1 ; then
+        CMakeCommand="cmake3"
+    elif command -v cmake >/dev/null 2>&1 ; then
+        CMakeCommand="cmake"
+    else
+        echo "This package requires CMake, please install it first."
+        echo "Then you may use this script to configure the CMake build."
+        echo "Note: pass --cmake=PATH to use cmake in non-standard locations."
+        exit 1;
+    fi
+fi
 
-            build_type=`bro-config --build_type`
+if [ -z "$zeekdist" ]; then
+    if type zeek-config >/dev/null 2>&1; then
+       zeek_config="zeek-config"
+    elif type bro-config >/dev/null 2>&1; then
+       zeek_config="bro-config"
+    fi
+
+    if [ -n "${zeek_config}" ]; then
+        if ${zeek_config} --cmake_dir >/dev/null 2>&1; then
+            # Have a newer version of zeek-config that has needed flags
+            append_cache_entry BRO_CONFIG_PREFIX PATH `${zeek_config} --prefix`
+            append_cache_entry BRO_CONFIG_INCLUDE_DIR PATH `${zeek_config} --include_dir`
+            append_cache_entry BRO_CONFIG_PLUGIN_DIR PATH `${zeek_config} --plugin_dir`
+            append_cache_entry BRO_CONFIG_CMAKE_DIR PATH `${zeek_config} --cmake_dir`
+            append_cache_entry CMAKE_MODULE_PATH PATH `${zeek_config} --cmake_dir`
+
+            build_type=`${zeek_config} --build_type`
 
             if [ "$build_type" = "debug" ]; then
                 append_cache_entry BRO_PLUGIN_ENABLE_DEBUG BOOL true
             fi
 
             if [ -z "$binpac_root" ]; then
-                append_cache_entry BinPAC_ROOT_DIR PATH `bro-config --binpac_root`
+                append_cache_entry BinPAC_ROOT_DIR PATH `${zeek_config} --binpac_root`
             fi
 
             if [ -z "$broker_root" ]; then
-                append_cache_entry BROKER_ROOT_DIR PATH `bro-config --broker_root`
+                append_cache_entry BROKER_ROOT_DIR PATH `${zeek_config} --broker_root`
             fi
 
             if [ -z "$caf_root" ]; then
-                append_cache_entry CAF_ROOT_DIR PATH `bro-config --caf_root`
+                append_cache_entry CAF_ROOT_DIR PATH `${zeek_config} --caf_root`
             fi
         else
-            brodist=`bro-config --bro_dist 2> /dev/null`
+            # Using legacy bro-config, so we must use the "--bro_dist" option.
+            zeekdist=`${zeek_config} --bro_dist 2> /dev/null`
 
-            if [ ! -e "$brodist/bro-path-dev.in" ]; then
-                echo "$brodist does not appear to be a valid Bro source tree."
+            if [ ! -e "$zeekdist/zeek-path-dev.in" ]; then
+                echo "$zeekdist does not appear to be a valid Zeek source tree."
                 exit 1
             fi
 
-            append_cache_entry BRO_DIST PATH $brodist
-            append_cache_entry CMAKE_MODULE_PATH PATH $brodist/cmake
+            # BRO_DIST is needed to support legacy Bro plugins
+            append_cache_entry BRO_DIST  PATH $zeekdist
+            append_cache_entry ZEEK_DIST PATH $zeekdist
+            append_cache_entry CMAKE_MODULE_PATH PATH $zeekdist/cmake
         fi
     else
-        echo "Either 'bro-config' must be in PATH or '--bro-dist=<path>' used"
+        echo "Either 'zeek-config' must be in PATH or '--zeek-dist=<path>' used"
         exit 1
     fi
 else
-    if [ ! -e "$brodist/bro-path-dev.in" ]; then
-      echo "$brodist does not appear to be a valid Bro source tree."
+    if [ ! -e "$zeekdist/zeek-path-dev.in" -a ! -e "$zeekdist/bro-path-dev.in" ]; then
+      echo "$zeekdist does not appear to be a valid Zeek source tree."
       exit 1
     fi
 
-    append_cache_entry BRO_DIST PATH $brodist
-    append_cache_entry CMAKE_MODULE_PATH PATH $brodist/cmake
+    # BRO_DIST is needed to support legacy Bro plugins
+    append_cache_entry BRO_DIST  PATH $zeekdist
+    append_cache_entry ZEEK_DIST PATH $zeekdist
+    append_cache_entry CMAKE_MODULE_PATH PATH $zeekdist/cmake
 fi
 
 if [ "$installroot" != "default" ]; then
@@ -174,12 +199,12 @@ if [ "$installroot" != "default" ]; then
 fi
 
 echo "Build Directory        : $builddir"
-echo "Bro Source Directory   : $brodist"
+echo "Zeek Source Directory  : $zeekdist"
 
 mkdir -p $builddir
 cd $builddir
 
-cmake $CMakeCacheEntries ..
+"$CMakeCommand" $CMakeCacheEntries ..
 
 echo "# This is the command used to configure this build" > config.status
 echo $command >> config.status

--- a/scripts/Salesforce/GQUIC/__load__.zeek
+++ b/scripts/Salesforce/GQUIC/__load__.zeek
@@ -3,5 +3,6 @@
 #
 
 @load ./main
+@load ./gquic_events.zeek
 
 @load-sigs ./dpd.sig

--- a/scripts/Salesforce/GQUIC/gquic_events.zeek
+++ b/scripts/Salesforce/GQUIC/gquic_events.zeek
@@ -1,5 +1,3 @@
-@load Salesforce/GQUIC
-
 event gquic_packet(c: connection, is_orig: bool, hdr: GQUIC::PublicHeader)
 	{
 #	print "gquic_packet", c$id, is_orig, hdr;

--- a/scripts/__load__.zeek
+++ b/scripts/__load__.zeek
@@ -1,7 +1,5 @@
 #
-# This is loaded unconditionally at Bro startup to initialze built-ins.
+# This is loaded unconditionally at Zeek startup to initialze built-ins.
 #
 
 @load ./init.zeek
-#@load Salesforce/GQUIC
-@load ./gquic_events.zeek

--- a/scripts/__preload__.zeek
+++ b/scripts/__preload__.zeek
@@ -1,11 +1,11 @@
 #
-# This is loaded unconditionally at Bro startup before any of the BiFs
+# This is loaded unconditionally at Zeek startup before any of the BiFs
 # defined by the plugin become available.
 #
 # This is primarily for defining types that BiFs already depend on.
 # If you need to do any other unconditional initialization (usually that's
-# just for other BiF elements), that should go into __load__.bro instead.
+# just for other BiF elements), that should go into __load__.zeek instead.
 #
 
-@load ./types.bro
+@load ./types.zeek
 

--- a/src/GQUIC.cc
+++ b/src/GQUIC.cc
@@ -8,7 +8,7 @@
 #include "GQUIC.h"
 #include "gquic_pac.h"
 
-using namespace analyzer::gquic;
+using namespace zeek::analyzer::gquic;
 
 GQUIC_Analyzer::GQUIC_Analyzer(Connection* conn)
 : Analyzer("GQUIC", conn)
@@ -36,7 +36,7 @@ void GQUIC_Analyzer::Done()
 	}
 
 void GQUIC_Analyzer::DeliverPacket(int len, const u_char* data, bool orig,
-                                   uint64 seq, const IP_Hdr* ip,
+                                   uint64_t seq, const IP_Hdr* ip,
                                    int caplen)
 	{
 	Analyzer::DeliverPacket(len, data, orig, seq, ip, caplen);
@@ -47,6 +47,6 @@ void GQUIC_Analyzer::DeliverPacket(int len, const u_char* data, bool orig,
 		}
 	catch ( const binpac::Exception& e )
 		{
-		ProtocolViolation(fmt("Binpac exception: %s", e.c_msg()));
+		ProtocolViolation(zeek::util::fmt("Binpac exception: %s", e.c_msg()));
 		}
 	}

--- a/src/GQUIC.h
+++ b/src/GQUIC.h
@@ -9,7 +9,11 @@
 #ifndef ANALYZER_PROTOCOL_GQUIC_GQUIC_H
 #define ANALYZER_PROTOCOL_GQUIC_GQUIC_H
 
+#if ZEEK_VERSION_NUMBER >= 40100
 #include <zeek/packet_analysis/protocol/udp/UDPSessionAdapter.h>
+#else
+#include <zeek/analyzer/protocol/udp/UDP.h>
+#endif
 #include <zeek/analyzer/protocol/pia/PIA.h>
 
 namespace binpac  {

--- a/src/GQUIC.h
+++ b/src/GQUIC.h
@@ -9,8 +9,8 @@
 #ifndef ANALYZER_PROTOCOL_GQUIC_GQUIC_H
 #define ANALYZER_PROTOCOL_GQUIC_GQUIC_H
 
-#include "analyzer/protocol/udp/UDP.h"
-#include "analyzer/protocol/pia/PIA.h"
+#include <zeek/packet_analysis/protocol/udp/UDPSessionAdapter.h>
+#include <zeek/analyzer/protocol/pia/PIA.h>
 
 namespace binpac  {
    namespace GQUIC {
@@ -18,19 +18,19 @@ namespace binpac  {
    }
 }
 
-namespace analyzer { namespace gquic {
+namespace zeek::analyzer { namespace gquic {
 
-class GQUIC_Analyzer : public analyzer::Analyzer {
+class GQUIC_Analyzer : public zeek::analyzer::Analyzer {
 public:
-	GQUIC_Analyzer(Connection* conn);
+	GQUIC_Analyzer(zeek::Connection* conn);
 	virtual ~GQUIC_Analyzer();
 
 	virtual void Done();
 	virtual void DeliverPacket(int len, const u_char* data, bool orig,
-	                           uint64 seq, const IP_Hdr* ip,
+	                           uint64_t seq, const IP_Hdr* ip,
 	                           int caplen);
 
-	static analyzer::Analyzer* Instantiate(Connection* conn)
+	static analyzer::Analyzer* Instantiate(zeek::Connection* conn)
 		{ return new GQUIC_Analyzer(conn); }
 
 protected:
@@ -43,6 +43,6 @@ protected:
 	binpac::GQUIC::GQUIC_Conn* interp;
 };
 
-} } // namespace analyzer::* 
+} } // namespace zeek::analyzer::*
 
 #endif

--- a/src/Plugin.cc
+++ b/src/Plugin.cc
@@ -5,19 +5,21 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
+#include <zeek/analyzer/Component.h>
+
 #include "GQUIC.h"
 #include "Plugin.h"
 
-namespace plugin { namespace Salesforce_GQUIC { Plugin plugin; } }
+namespace zeek::plugin { namespace Salesforce_GQUIC { Plugin plugin; } }
 
-using namespace plugin::Salesforce_GQUIC;
+using namespace zeek::plugin::Salesforce_GQUIC;
 
-plugin::Configuration Plugin::Configure()
+zeek::plugin::Configuration Plugin::Configure()
 	{
-	auto c = new ::analyzer::Component("GQUIC",
-		::analyzer::gquic::GQUIC_Analyzer::Instantiate);
+	auto c = new zeek::analyzer::Component("GQUIC",
+		zeek::analyzer::gquic::GQUIC_Analyzer::Instantiate);
 	AddComponent(c);
-	plugin::Configuration config;
+	zeek::plugin::Configuration config;
 	config.name = "Salesforce::GQUIC";
 	config.description = "Google QUIC (GQUIC) protocol analyzer for Q039-Q046";
 	config.version.major = 1;

--- a/src/Plugin.h
+++ b/src/Plugin.h
@@ -5,24 +5,22 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
-#ifndef BRO_PLUGIN_SALESFORCE_GQUIC
-#define BRO_PLUGIN_SALESFORCE_GQUIC
+#ifndef ZEEK_PLUGIN_SALESFORCE_GQUIC
+#define ZEEK_PLUGIN_SALESFORCE_GQUIC
 
-#include <plugin/Plugin.h>
+#include <zeek/plugin/Plugin.h>
 
-namespace plugin {
-namespace Salesforce_GQUIC {
+namespace zeek::plugin::Salesforce_GQUIC {
 
-class Plugin : public ::plugin::Plugin
+class Plugin : public zeek::plugin::Plugin
 {
 protected:
 	// Overridden from plugin::Plugin.
-	plugin::Configuration Configure() override;
+	zeek::plugin::Configuration Configure() override;
 };
 
 extern Plugin plugin;
 
-}
 }
 
 #endif

--- a/src/gquic-analyzer.pac
+++ b/src/gquic-analyzer.pac
@@ -27,17 +27,17 @@ refine connection GQUIC_Conn += {
 		// Add the gquic string to conn.log
 		void confirm()
 			{
-			bro_analyzer()->ProtocolConfirmation();
+			zeek_analyzer()->ProtocolConfirmation();
 
-			if ( BifConst::GQUIC::skip_after_confirm )
-				bro_analyzer()->SetSkip(true);
+			if ( zeek::BifConst::GQUIC::skip_after_confirm )
+				zeek_analyzer()->SetSkip(true);
 			}
 
 		uint16 extract_gquic_version(const uint8* version_bytes)
 			{
 			if ( version_bytes[0] != 'Q' )
 				{
-				bro_analyzer()->ProtocolViolation("invalid GQUIC Version",
+				zeek_analyzer()->ProtocolViolation("invalid GQUIC Version",
 				    reinterpret_cast<const char*>(version_bytes), 4);
 				return 0;
 				}
@@ -46,7 +46,7 @@ refine connection GQUIC_Conn += {
 				{
 				if ( ! isdigit(version_bytes[i]) )
 					{
-					bro_analyzer()->ProtocolViolation(
+					zeek_analyzer()->ProtocolViolation(
 					    "invalid GQUIC Version",
 				        reinterpret_cast<const char*>(version_bytes), 4);
 					return 0;
@@ -85,9 +85,9 @@ function process_packet(pkt: GQUIC_Packet, is_orig: bool): bool
 					auto p = potential_client_versions.emplace(pkt_version);
 
 					if ( gquic_client_version && p.second )
-						BifEvent::generate_gquic_client_version(
-						    bro_analyzer(),
-						    bro_analyzer()->Conn(),
+						zeek::BifEvent::enqueue_gquic_client_version(
+						    zeek_analyzer(),
+						    zeek_analyzer()->Conn(),
 						    pkt_version);
 					}
 
@@ -110,35 +110,39 @@ function process_packet(pkt: GQUIC_Packet, is_orig: bool): bool
 			if ( gquic_packet )
 				{
 				//Populate standard GQUIC packet characteristics
-				auto rv = new RecordVal(BifType::Record::GQUIC::PublicHeader);
-				rv->Assign(0, new Val(pkt_num, TYPE_COUNT));
+				auto rv = zeek::make_intrusive<zeek::RecordVal>(zeek::BifType::Record::GQUIC::PublicHeader);
+				rv->Assign(0, zeek::val_mgr->Count(pkt_num));
 
 				if ( ${pkt.reg_pkt.cid}->present_case_index() )
 					{
 					auto bytes = ${pkt.reg_pkt.cid.bytes};
 					auto ptr = reinterpret_cast<const char*>(bytes->data());
-					rv->Assign(1, new StringVal(bytes->size(), ptr));
+					rv->Assign(1, new zeek::StringVal(bytes->size(), ptr));
 					}
-					rv->Assign(2, new Val(${pkt.flags.is_long}, TYPE_BOOL));
+					rv->Assign(2, zeek::val_mgr->Bool(${pkt.flags.is_long}));
 				if ( ${pkt.reg_pkt}->version_case_index() )
-					rv->Assign(3, new Val(pkt_version, TYPE_COUNT));
+					rv->Assign(3, zeek::val_mgr->Count(pkt_version));
 
 				if ( ${pkt.flags.hello_length} == true )
 					{
 					if ( ${pkt.search.expected_string.hello_check} == true )
 						{
-						hello_packet_creation(${pkt}, is_orig, rv);
+						zeek::BifEvent::enqueue_gquic_hello(zeek_analyzer(), zeek_analyzer()->Conn(), is_orig, rv,
+																								{zeek::AdoptRef{}, hello_packet_creation(${pkt}, is_orig)});
 						}
 					else if ( ${pkt.search.expected_string.rej_check} == true)
-						rej_packet_creation(${pkt}, is_orig, rv);
+						{
+						zeek::BifEvent::enqueue_gquic_rej(zeek_analyzer(), zeek_analyzer()->Conn(), is_orig, rv,
+																							{zeek::AdoptRef{}, rej_packet_creation(${pkt}, is_orig)});
+						}
 					else
 						{
-						BifEvent::generate_gquic_packet(bro_analyzer(), bro_analyzer()->Conn(), is_orig, rv);
+						zeek::BifEvent::enqueue_gquic_packet(zeek_analyzer(), zeek_analyzer()->Conn(), is_orig, rv);
 						}
 					}
 				else
 					{
-					BifEvent::generate_gquic_packet(bro_analyzer(), bro_analyzer()->Conn(), is_orig, rv);
+					zeek::BifEvent::enqueue_gquic_packet(zeek_analyzer(), zeek_analyzer()->Conn(), is_orig, rv);
 					}
 				}
 			}
@@ -157,9 +161,9 @@ function process_packet(pkt: GQUIC_Packet, is_orig: bool): bool
 					auto p = potential_client_versions.emplace(pkt_version);
 
 					if ( gquic_client_version && p.second )
-						BifEvent::generate_gquic_client_version(
-								bro_analyzer(),
-								bro_analyzer()->Conn(),
+						zeek::BifEvent::enqueue_gquic_client_version(
+								zeek_analyzer(),
+								zeek_analyzer()->Conn(),
 								pkt_version);
 					}
 
@@ -182,36 +186,40 @@ function process_packet(pkt: GQUIC_Packet, is_orig: bool): bool
 			if ( gquic_packet )
 				{
 				//Populate standard GQUIC packet characteristics
-				auto rv = new RecordVal(BifType::Record::GQUIC::PublicHeader);
-				rv->Assign(0, new Val(pkt_num, TYPE_COUNT));
+				auto rv = zeek::make_intrusive<zeek::RecordVal>(zeek::BifType::Record::GQUIC::PublicHeader);
+				rv->Assign(0, zeek::val_mgr->Count(pkt_num));
 
 				if ( ${pkt.old_pkt.cid}->present_case_index() )
 					{
 					auto bytes = ${pkt.old_pkt.cid.bytes};
 					auto ptr = reinterpret_cast<const char*>(bytes->data());
-					rv->Assign(1, new StringVal(bytes->size(), ptr));
+					rv->Assign(1, new zeek::StringVal(bytes->size(), ptr));
 					}
-				rv->Assign(2, new Val(${pkt.flags.have_version}, TYPE_BOOL));
+				rv->Assign(2, zeek::val_mgr->Bool(${pkt.flags.have_version}));
 				if ( ${pkt.old_pkt}->version_case_index() )
-					rv->Assign(3, new Val(pkt_version, TYPE_COUNT));
+					rv->Assign(3, zeek::val_mgr->Count(pkt_version));
 
 				if ( ${pkt.flags.hello_length} == true )
 					{
 					if ( ${pkt.search.expected_string.hello_check} == true )
 						{
-						hello_packet_creation(${pkt}, is_orig, rv);
+						zeek::BifEvent::enqueue_gquic_hello(zeek_analyzer(), zeek_analyzer()->Conn(), is_orig, rv,
+																							  {zeek::AdoptRef{}, hello_packet_creation(${pkt}, is_orig)});
 						}
 					else if ( ${pkt.search.expected_string.rej_check} == true)
-						rej_packet_creation(${pkt}, is_orig, rv);	
+						{
+						zeek::BifEvent::enqueue_gquic_rej(zeek_analyzer(), zeek_analyzer()->Conn(), is_orig, rv,
+																							{zeek::AdoptRef{}, rej_packet_creation(${pkt}, is_orig)});
+						}
 					else
 						{
-						BifEvent::generate_gquic_packet(bro_analyzer(), bro_analyzer()->Conn(), is_orig, rv);
+						zeek::BifEvent::enqueue_gquic_packet(zeek_analyzer(), zeek_analyzer()->Conn(), is_orig, rv);
 						}
 					}
 
 				else
 					{
-					BifEvent::generate_gquic_packet(bro_analyzer(), bro_analyzer()->Conn(), is_orig, rv);
+					zeek::BifEvent::enqueue_gquic_packet(zeek_analyzer(), zeek_analyzer()->Conn(), is_orig, rv);
 					}
 				}
 			}
@@ -223,121 +231,121 @@ function process_packet(pkt: GQUIC_Packet, is_orig: bool): bool
 		return true;
 		%}
 
-	function hello_packet_creation(pkt: GQUIC_Packet, is_orig: bool, rv: RecordVal(PublicHeader)): bool
+	function hello_packet_creation(pkt: GQUIC_Packet, is_orig: bool): ZeekVal
 		%{
 		//Populate the characteristics of the Hello Packet
-		auto hi_1 = new RecordVal(BifType::Record::GQUIC::HelloInfo);
+		static auto hello_info = zeek::id::find_type<zeek::RecordType>("GQUIC::HelloInfo");
+		auto* hi_1 = new zeek::RecordVal(hello_info);
 		if ( ${pkt.search.build_hello.yes.tag_number} )
 			{
 			auto bytes = ${pkt.search.build_hello.yes.tag_number};
-			hi_1->Assign(0, new Val(bytes, TYPE_COUNT));
-		    	hi_1->Assign(1, new StringVal(${pkt.search.build_hello.yes.other_tags.seek_tags}.length(), (const char*)${pkt.search.build_hello.yes.other_tags.seek_tags}.begin()));
+			hi_1->Assign(0, zeek::val_mgr->Count(bytes));
+			hi_1->Assign(1, new zeek::StringVal(${pkt.search.build_hello.yes.other_tags.seek_tags}.length(), (const char*)${pkt.search.build_hello.yes.other_tags.seek_tags}.begin()));
 			auto bytes2 = ${pkt.search.build_hello.yes.p_tag_offset};
-			hi_1->Assign(2, new Val(bytes2, TYPE_COUNT));
+			hi_1->Assign(2, zeek::val_mgr->Count(bytes2));
 			}
 		if ( ${pkt.search.build_hello.yes.other_tags.sni_check} )
-			hi_1->Assign(3, new StringVal(${pkt.search.build_hello.yes.sni.collect}.length(), (const char*)${pkt.search.build_hello.yes.sni.collect}.begin()));
+			hi_1->Assign(3, new zeek::StringVal(${pkt.search.build_hello.yes.sni.collect}.length(), (const char*)${pkt.search.build_hello.yes.sni.collect}.begin()));
 		if ( ${pkt.search.build_hello.yes.other_tags.stk_check} )
-			hi_1->Assign(4, new StringVal(${pkt.search.build_hello.yes.stk.collect}.length(), (const char*)${pkt.search.build_hello.yes.stk.collect}.begin()));
+			hi_1->Assign(4, new zeek::StringVal(${pkt.search.build_hello.yes.stk.collect}.length(), (const char*)${pkt.search.build_hello.yes.stk.collect}.begin()));
 		if ( ${pkt.search.build_hello.yes.other_tags.sno_check} )
-			hi_1->Assign(5, new StringVal(${pkt.search.build_hello.yes.sno.collect}.length(), (const char*)${pkt.search.build_hello.yes.sno.collect}.begin()));
+			hi_1->Assign(5, new zeek::StringVal(${pkt.search.build_hello.yes.sno.collect}.length(), (const char*)${pkt.search.build_hello.yes.sno.collect}.begin()));
 		if ( ${pkt.search.build_hello.yes.other_tags.ver_check} )
-			hi_1->Assign(6, new StringVal(${pkt.search.build_hello.yes.ver.collect}.length(), (const char*)${pkt.search.build_hello.yes.ver.collect}.begin()));
+			hi_1->Assign(6, new zeek::StringVal(${pkt.search.build_hello.yes.ver.collect}.length(), (const char*)${pkt.search.build_hello.yes.ver.collect}.begin()));
 		if ( ${pkt.search.build_hello.yes.other_tags.ccs_check} )
-			hi_1->Assign(7, new StringVal(${pkt.search.build_hello.yes.ccs.collect}.length(), (const char*)${pkt.search.build_hello.yes.ccs.collect}.begin()));
+			hi_1->Assign(7, new zeek::StringVal(${pkt.search.build_hello.yes.ccs.collect}.length(), (const char*)${pkt.search.build_hello.yes.ccs.collect}.begin()));
 		if ( ${pkt.search.build_hello.yes.other_tags.nonc_check} )
-			hi_1->Assign(8, new StringVal(${pkt.search.build_hello.yes.nonc.collect}.length(), (const char*)${pkt.search.build_hello.yes.nonc.collect}.begin()));
+			hi_1->Assign(8, new zeek::StringVal(${pkt.search.build_hello.yes.nonc.collect}.length(), (const char*)${pkt.search.build_hello.yes.nonc.collect}.begin()));
 		if ( ${pkt.search.build_hello.yes.other_tags.mspc_check} )
-			hi_1->Assign(9, new StringVal(${pkt.search.build_hello.yes.mspc.collect}.length(), (const char*)${pkt.search.build_hello.yes.mspc.collect}.begin()));
+			hi_1->Assign(9, new zeek::StringVal(${pkt.search.build_hello.yes.mspc.collect}.length(), (const char*)${pkt.search.build_hello.yes.mspc.collect}.begin()));
 		if ( ${pkt.search.build_hello.yes.other_tags.aead_check} )
-			hi_1->Assign(10, new StringVal(${pkt.search.build_hello.yes.aead.collect}.length(), (const char*)${pkt.search.build_hello.yes.aead.collect}.begin()));
+			hi_1->Assign(10, new zeek::StringVal(${pkt.search.build_hello.yes.aead.collect}.length(), (const char*)${pkt.search.build_hello.yes.aead.collect}.begin()));
 		if ( ${pkt.search.build_hello.yes.other_tags.uaid_check} )
-			hi_1->Assign(11, new StringVal(${pkt.search.build_hello.yes.uaid.collect}.length(), (const char*)${pkt.search.build_hello.yes.uaid.collect}.begin()));
+			hi_1->Assign(11, new zeek::StringVal(${pkt.search.build_hello.yes.uaid.collect}.length(), (const char*)${pkt.search.build_hello.yes.uaid.collect}.begin()));
 		if ( ${pkt.search.build_hello.yes.other_tags.scid_check} )
-			hi_1->Assign(12, new StringVal(${pkt.search.build_hello.yes.scid.collect}.length(), (const char*)${pkt.search.build_hello.yes.scid.collect}.begin()));
+			hi_1->Assign(12, new zeek::StringVal(${pkt.search.build_hello.yes.scid.collect}.length(), (const char*)${pkt.search.build_hello.yes.scid.collect}.begin()));
 		if ( ${pkt.search.build_hello.yes.other_tags.tcid_check} )
-			hi_1->Assign(13, new StringVal(${pkt.search.build_hello.yes.tcid.collect}.length(), (const char*)${pkt.search.build_hello.yes.tcid.collect}.begin()));
+			hi_1->Assign(13, new zeek::StringVal(${pkt.search.build_hello.yes.tcid.collect}.length(), (const char*)${pkt.search.build_hello.yes.tcid.collect}.begin()));
 		if ( ${pkt.search.build_hello.yes.other_tags.pdmd_check} )
-			hi_1->Assign(14, new StringVal(${pkt.search.build_hello.yes.pdmd.collect}.length(), (const char*)${pkt.search.build_hello.yes.pdmd.collect}.begin()));
+			hi_1->Assign(14, new zeek::StringVal(${pkt.search.build_hello.yes.pdmd.collect}.length(), (const char*)${pkt.search.build_hello.yes.pdmd.collect}.begin()));
 		if ( ${pkt.search.build_hello.yes.other_tags.smhl_check} )
-			hi_1->Assign(15, new StringVal(${pkt.search.build_hello.yes.smhl.collect}.length(), (const char*)${pkt.search.build_hello.yes.smhl.collect}.begin()));
+			hi_1->Assign(15, new zeek::StringVal(${pkt.search.build_hello.yes.smhl.collect}.length(), (const char*)${pkt.search.build_hello.yes.smhl.collect}.begin()));
 		if ( ${pkt.search.build_hello.yes.other_tags.icsl_check} )
-			hi_1->Assign(16, new StringVal(${pkt.search.build_hello.yes.icsl.collect}.length(), (const char*)${pkt.search.build_hello.yes.icsl.collect}.begin()));
+			hi_1->Assign(16, new zeek::StringVal(${pkt.search.build_hello.yes.icsl.collect}.length(), (const char*)${pkt.search.build_hello.yes.icsl.collect}.begin()));
 		if ( ${pkt.search.build_hello.yes.other_tags.ctim_check} )
-			hi_1->Assign(17, new StringVal(${pkt.search.build_hello.yes.ctim.collect}.length(), (const char*)${pkt.search.build_hello.yes.ctim.collect}.begin()));
+			hi_1->Assign(17, new zeek::StringVal(${pkt.search.build_hello.yes.ctim.collect}.length(), (const char*)${pkt.search.build_hello.yes.ctim.collect}.begin()));
 		if ( ${pkt.search.build_hello.yes.other_tags.nonp_check} )
-			hi_1->Assign(18, new StringVal(${pkt.search.build_hello.yes.nonp.collect}.length(), (const char*)${pkt.search.build_hello.yes.nonp.collect}.begin()));
+			hi_1->Assign(18, new zeek::StringVal(${pkt.search.build_hello.yes.nonp.collect}.length(), (const char*)${pkt.search.build_hello.yes.nonp.collect}.begin()));
 		if ( ${pkt.search.build_hello.yes.other_tags.pubs_check} )
-			hi_1->Assign(19, new StringVal(${pkt.search.build_hello.yes.pubs.collect}.length(), (const char*)${pkt.search.build_hello.yes.pubs.collect}.begin()));
+			hi_1->Assign(19, new zeek::StringVal(${pkt.search.build_hello.yes.pubs.collect}.length(), (const char*)${pkt.search.build_hello.yes.pubs.collect}.begin()));
 		if ( ${pkt.search.build_hello.yes.other_tags.mids_check} )
-			hi_1->Assign(20, new StringVal(${pkt.search.build_hello.yes.mids.collect}.length(), (const char*)${pkt.search.build_hello.yes.mids.collect}.begin()));
+			hi_1->Assign(20, new zeek::StringVal(${pkt.search.build_hello.yes.mids.collect}.length(), (const char*)${pkt.search.build_hello.yes.mids.collect}.begin()));
 		if ( ${pkt.search.build_hello.yes.other_tags.scls_check} )
-			hi_1->Assign(21, new StringVal(${pkt.search.build_hello.yes.scls.collect}.length(), (const char*)${pkt.search.build_hello.yes.scls.collect}.begin()));
+			hi_1->Assign(21, new zeek::StringVal(${pkt.search.build_hello.yes.scls.collect}.length(), (const char*)${pkt.search.build_hello.yes.scls.collect}.begin()));
 		if ( ${pkt.search.build_hello.yes.other_tags.kexs_check} )
-			hi_1->Assign(22, new StringVal(${pkt.search.build_hello.yes.kexs.collect}.length(), (const char*)${pkt.search.build_hello.yes.kexs.collect}.begin()));
+			hi_1->Assign(22, new zeek::StringVal(${pkt.search.build_hello.yes.kexs.collect}.length(), (const char*)${pkt.search.build_hello.yes.kexs.collect}.begin()));
 		if ( ${pkt.search.build_hello.yes.other_tags.xlct_check} )
-			hi_1->Assign(23, new StringVal(${pkt.search.build_hello.yes.xlct.collect}.length(), (const char*)${pkt.search.build_hello.yes.xlct.collect}.begin()));
+			hi_1->Assign(23, new zeek::StringVal(${pkt.search.build_hello.yes.xlct.collect}.length(), (const char*)${pkt.search.build_hello.yes.xlct.collect}.begin()));
 		if ( ${pkt.search.build_hello.yes.other_tags.csct_check} )
-			hi_1->Assign(24, new StringVal(${pkt.search.build_hello.yes.csct.collect}.length(), (const char*)${pkt.search.build_hello.yes.csct.collect}.begin()));
+			hi_1->Assign(24, new zeek::StringVal(${pkt.search.build_hello.yes.csct.collect}.length(), (const char*)${pkt.search.build_hello.yes.csct.collect}.begin()));
 		if ( ${pkt.search.build_hello.yes.other_tags.copt_check} )
-			hi_1->Assign(25, new StringVal(${pkt.search.build_hello.yes.copt.collect}.length(), (const char*)${pkt.search.build_hello.yes.copt.collect}.begin()));
+			hi_1->Assign(25, new zeek::StringVal(${pkt.search.build_hello.yes.copt.collect}.length(), (const char*)${pkt.search.build_hello.yes.copt.collect}.begin()));
 		if ( ${pkt.search.build_hello.yes.other_tags.ccrt_check} )
-			hi_1->Assign(26, new StringVal(${pkt.search.build_hello.yes.ccrt.collect}.length(), (const char*)${pkt.search.build_hello.yes.ccrt.collect}.begin()));
+			hi_1->Assign(26, new zeek::StringVal(${pkt.search.build_hello.yes.ccrt.collect}.length(), (const char*)${pkt.search.build_hello.yes.ccrt.collect}.begin()));
 		if ( ${pkt.search.build_hello.yes.other_tags.irtt_check} )
-			hi_1->Assign(27, new StringVal(${pkt.search.build_hello.yes.irtt.collect}.length(), (const char*)${pkt.search.build_hello.yes.irtt.collect}.begin()));
+			hi_1->Assign(27, new zeek::StringVal(${pkt.search.build_hello.yes.irtt.collect}.length(), (const char*)${pkt.search.build_hello.yes.irtt.collect}.begin()));
 		if ( ${pkt.search.build_hello.yes.other_tags.cetv_check} )
-			hi_1->Assign(28, new StringVal(${pkt.search.build_hello.yes.cetv.collect}.length(), (const char*)${pkt.search.build_hello.yes.cetv.collect}.begin()));
+			hi_1->Assign(28, new zeek::StringVal(${pkt.search.build_hello.yes.cetv.collect}.length(), (const char*)${pkt.search.build_hello.yes.cetv.collect}.begin()));
 		if ( ${pkt.search.build_hello.yes.other_tags.cfcw_check} )
-			hi_1->Assign(29, new StringVal(${pkt.search.build_hello.yes.cfcw.collect}.length(), (const char*)${pkt.search.build_hello.yes.cfcw.collect}.begin()));
+			hi_1->Assign(29, new zeek::StringVal(${pkt.search.build_hello.yes.cfcw.collect}.length(), (const char*)${pkt.search.build_hello.yes.cfcw.collect}.begin()));
 		if ( ${pkt.search.build_hello.yes.other_tags.sfcw_check} )
-			hi_1->Assign(30, new StringVal(${pkt.search.build_hello.yes.sfcw.collect}.length(), (const char*)${pkt.search.build_hello.yes.sfcw.collect}.begin()));
-		BifEvent::generate_gquic_hello(bro_analyzer(), bro_analyzer()->Conn(), is_orig, rv, hi_1);
-		return true;
+			hi_1->Assign(30, new zeek::StringVal(${pkt.search.build_hello.yes.sfcw.collect}.length(), (const char*)${pkt.search.build_hello.yes.sfcw.collect}.begin()));
+		return hi_1;
 	%}
 
-	function rej_packet_creation(pkt: GQUIC_Packet, is_orig: bool, rv: RecordVal(PublicHeader)): bool
+	function rej_packet_creation(pkt: GQUIC_Packet, is_orig: bool): ZeekVal
 		%{
-		auto rej_1 = new RecordVal(BifType::Record::GQUIC::RejInfo);
+		static auto rej_info = zeek::id::find_type<zeek::RecordType>("GQUIC::RejInfo");
+		auto* rej_1 = new zeek::RecordVal(rej_info);
 		if ( ${pkt.search.build_hello.rej.tag_number} )
-			rej_1->Assign(0, new Val(${pkt.search.build_hello.rej.tag_number}, TYPE_COUNT));
-		rej_1->Assign(1, new StringVal(${pkt.search.build_hello.rej.other_tags.seek_tags}.length(), (const char*)${pkt.search.build_hello.rej.other_tags.seek_tags}.begin()));
+			rej_1->Assign(0, zeek::val_mgr->Count(${pkt.search.build_hello.rej.tag_number}));
+		rej_1->Assign(1, new zeek::StringVal(${pkt.search.build_hello.rej.other_tags.seek_tags}.length(), (const char*)${pkt.search.build_hello.rej.other_tags.seek_tags}.begin()));
 		if ( ${pkt.search.build_hello.rej.other_tags.stk_check} )
-			rej_1->Assign(2, new StringVal(${pkt.search.build_hello.rej.stk.collect}.length(), (const char*)${pkt.search.build_hello.rej.stk.collect}.begin()));
+			rej_1->Assign(2, new zeek::StringVal(${pkt.search.build_hello.rej.stk.collect}.length(), (const char*)${pkt.search.build_hello.rej.stk.collect}.begin()));
 		if ( ${pkt.search.build_hello.rej.other_tags.sno_check} )
-			rej_1->Assign(3, new StringVal(${pkt.search.build_hello.rej.sno.collect}.length(), (const char*)${pkt.search.build_hello.rej.sno.collect}.begin()));
+			rej_1->Assign(3, new zeek::StringVal(${pkt.search.build_hello.rej.sno.collect}.length(), (const char*)${pkt.search.build_hello.rej.sno.collect}.begin()));
 		if ( ${pkt.search.build_hello.rej.other_tags.svid_check} )
-			rej_1->Assign(4, new StringVal(${pkt.search.build_hello.rej.svid.collect}.length(), (const char*)${pkt.search.build_hello.rej.svid.collect}.begin()));
+			rej_1->Assign(4, new zeek::StringVal(${pkt.search.build_hello.rej.svid.collect}.length(), (const char*)${pkt.search.build_hello.rej.svid.collect}.begin()));
 		if ( ${pkt.search.build_hello.rej.other_tags.prof_check} )
-			rej_1->Assign(5, new StringVal(${pkt.search.build_hello.rej.prof.collect}.length(), (const char*)${pkt.search.build_hello.rej.prof.collect}.begin()));
+			rej_1->Assign(5, new zeek::StringVal(${pkt.search.build_hello.rej.prof.collect}.length(), (const char*)${pkt.search.build_hello.rej.prof.collect}.begin()));
 		if ( ${pkt.search.build_hello.rej.other_tags.scfg_check} )
-			rej_1->Assign(6, new StringVal(${pkt.search.build_hello.rej.scfg.collect.other_tags.seek_tags}.length(), (const char*)${pkt.search.build_hello.rej.scfg.collect.other_tags.seek_tags}.begin()));
+			rej_1->Assign(6, new zeek::StringVal(${pkt.search.build_hello.rej.scfg.collect.other_tags.seek_tags}.length(), (const char*)${pkt.search.build_hello.rej.scfg.collect.other_tags.seek_tags}.begin()));
 		if ( ${pkt.search.build_hello.rej.other_tags.rrej_check} )
-			rej_1->Assign(7, new StringVal(${pkt.search.build_hello.rej.rrej.collect}.length(), (const char*)${pkt.search.build_hello.rej.rrej.collect}.begin()));
+			rej_1->Assign(7, new zeek::StringVal(${pkt.search.build_hello.rej.rrej.collect}.length(), (const char*)${pkt.search.build_hello.rej.rrej.collect}.begin()));
 		if ( ${pkt.search.build_hello.rej.other_tags.sttl_check} )
-			rej_1->Assign(8, new StringVal(${pkt.search.build_hello.rej.sttl.collect}.length(), (const char*)${pkt.search.build_hello.rej.sttl.collect}.begin()));
+			rej_1->Assign(8, new zeek::StringVal(${pkt.search.build_hello.rej.sttl.collect}.length(), (const char*)${pkt.search.build_hello.rej.sttl.collect}.begin()));
 		if ( ${pkt.search.build_hello.rej.other_tags.csct_check} )
-			rej_1->Assign(9, new StringVal(${pkt.search.build_hello.rej.csct.collect}.length(), (const char*)${pkt.search.build_hello.rej.csct.collect}.begin()));
+			rej_1->Assign(9, new zeek::StringVal(${pkt.search.build_hello.rej.csct.collect}.length(), (const char*)${pkt.search.build_hello.rej.csct.collect}.begin()));
 		if ( ${pkt.search.build_hello.rej.scfg.collect.other_tags.ver_check} )
-			rej_1->Assign(10, new StringVal(${pkt.search.build_hello.rej.scfg.collect.ver.collect}.length(), (const char*)${pkt.search.build_hello.rej.scfg.collect.ver.collect}.begin()));
+			rej_1->Assign(10, new zeek::StringVal(${pkt.search.build_hello.rej.scfg.collect.ver.collect}.length(), (const char*)${pkt.search.build_hello.rej.scfg.collect.ver.collect}.begin()));
 		if ( ${pkt.search.build_hello.rej.scfg.collect.other_tags.aead_check} )
-			rej_1->Assign(11, new StringVal(${pkt.search.build_hello.rej.scfg.collect.aead.collect}.length(), (const char*)${pkt.search.build_hello.rej.scfg.collect.aead.collect}.begin()));
+			rej_1->Assign(11, new zeek::StringVal(${pkt.search.build_hello.rej.scfg.collect.aead.collect}.length(), (const char*)${pkt.search.build_hello.rej.scfg.collect.aead.collect}.begin()));
 		if ( ${pkt.search.build_hello.rej.scfg.collect.other_tags.scid_check} )
-			rej_1->Assign(12, new StringVal(${pkt.search.build_hello.rej.scfg.collect.scid.collect}.length(), (const char*)${pkt.search.build_hello.rej.scfg.collect.scid.collect}.begin()));
+			rej_1->Assign(12, new zeek::StringVal(${pkt.search.build_hello.rej.scfg.collect.scid.collect}.length(), (const char*)${pkt.search.build_hello.rej.scfg.collect.scid.collect}.begin()));
 		if ( ${pkt.search.build_hello.rej.scfg.collect.other_tags.pdmd_check} )
-			rej_1->Assign(13, new StringVal(${pkt.search.build_hello.rej.scfg.collect.pdmd.collect}.length(), (const char*)${pkt.search.build_hello.rej.scfg.collect.pdmd.collect}.begin()));
+			rej_1->Assign(13, new zeek::StringVal(${pkt.search.build_hello.rej.scfg.collect.pdmd.collect}.length(), (const char*)${pkt.search.build_hello.rej.scfg.collect.pdmd.collect}.begin()));
 		if ( ${pkt.search.build_hello.rej.scfg.collect.other_tags.tbkp_check} )
-			rej_1->Assign(14, new StringVal(${pkt.search.build_hello.rej.scfg.collect.tbkp.collect}.length(), (const char*)${pkt.search.build_hello.rej.scfg.collect.tbkp.collect}.begin()));
+			rej_1->Assign(14, new zeek::StringVal(${pkt.search.build_hello.rej.scfg.collect.tbkp.collect}.length(), (const char*)${pkt.search.build_hello.rej.scfg.collect.tbkp.collect}.begin()));
 		if ( ${pkt.search.build_hello.rej.scfg.collect.other_tags.pubs_check} )
-			rej_1->Assign(15, new StringVal(${pkt.search.build_hello.rej.scfg.collect.pubs.collect}.length(), (const char*)${pkt.search.build_hello.rej.scfg.collect.pubs.collect}.begin()));
+			rej_1->Assign(15, new zeek::StringVal(${pkt.search.build_hello.rej.scfg.collect.pubs.collect}.length(), (const char*)${pkt.search.build_hello.rej.scfg.collect.pubs.collect}.begin()));
 		if ( ${pkt.search.build_hello.rej.scfg.collect.other_tags.kexs_check} )
-			rej_1->Assign(16, new StringVal(${pkt.search.build_hello.rej.scfg.collect.kexs.collect}.length(), (const char*)${pkt.search.build_hello.rej.scfg.collect.kexs.collect}.begin()));
+			rej_1->Assign(16, new zeek::StringVal(${pkt.search.build_hello.rej.scfg.collect.kexs.collect}.length(), (const char*)${pkt.search.build_hello.rej.scfg.collect.kexs.collect}.begin()));
 		if ( ${pkt.search.build_hello.rej.scfg.collect.other_tags.obit_check} )
-			rej_1->Assign(17, new StringVal(${pkt.search.build_hello.rej.scfg.collect.obit.collect}.length(), (const char*)${pkt.search.build_hello.rej.scfg.collect.obit.collect}.begin()));
+			rej_1->Assign(17, new zeek::StringVal(${pkt.search.build_hello.rej.scfg.collect.obit.collect}.length(), (const char*)${pkt.search.build_hello.rej.scfg.collect.obit.collect}.begin()));
 		if ( ${pkt.search.build_hello.rej.scfg.collect.other_tags.expy_check} )
-			rej_1->Assign(18, new StringVal(${pkt.search.build_hello.rej.scfg.collect.expy.collect}.length(), (const char*)${pkt.search.build_hello.rej.scfg.collect.expy.collect}.begin()));
-		rej_1->Assign(19, new Val(${pkt.search.build_hello.rej.scfg.collect.tag_number}, TYPE_COUNT));
-		BifEvent::generate_gquic_rej(bro_analyzer(), bro_analyzer()->Conn(), is_orig, rv, rej_1);
-		return true;
+			rej_1->Assign(18, new zeek::StringVal(${pkt.search.build_hello.rej.scfg.collect.expy.collect}.length(), (const char*)${pkt.search.build_hello.rej.scfg.collect.expy.collect}.begin()));
+		rej_1->Assign(19, zeek::val_mgr->Count(${pkt.search.build_hello.rej.scfg.collect.tag_number}));
+		return rej_1;
 		%}
 
 
@@ -419,7 +427,7 @@ function process_packet(pkt: GQUIC_Packet, is_orig: bool): bool
 		auto gquic_is_big_endian = version == 0 || version >= 39;
 
 		if ( gquic_is_big_endian )
-			rval = ntohll(rval);
+			rval = zeek::ntohll(rval);
 		else
 			{
 #ifdef WORDS_BIGENDIAN

--- a/src/gquic.pac
+++ b/src/gquic.pac
@@ -3,8 +3,8 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
 
-%include binpac.pac
-%include bro.pac
+%include zeek/binpac.pac
+%include zeek/zeek.pac
 
 %extern{
 #include "GQUIC.h"
@@ -16,7 +16,7 @@ analyzer GQUIC withcontext {
     flow:       GQUIC_Flow;
 };
 
-connection GQUIC_Conn(bro_analyzer: BroAnalyzer) {
+connection GQUIC_Conn(zeek_analyzer: ZeekAnalyzer) {
     upflow   = GQUIC_Flow(true);
     downflow = GQUIC_Flow(false);
 };

--- a/zkg.meta
+++ b/zkg.meta
@@ -1,0 +1,4 @@
+[package]
+description = Protocol analyzer that detects, dissects, fingerprints, and logs GQUIC traffic
+script_dir = scripts/Salesforce/GQUIC
+build_command = ./configure && make

--- a/zkg.meta
+++ b/zkg.meta
@@ -2,3 +2,6 @@
 description = Protocol analyzer that detects, dissects, fingerprints, and logs GQUIC traffic
 script_dir = scripts/Salesforce/GQUIC
 build_command = ./configure && make
+depends =
+  zkg >=2.0
+  zeek >=4.0.0


### PR DESCRIPTION
Plugin updates for Zeek v4.1.x compatibility

- based on of the existing Zeek v4.0.x compatibility pull request
  (salesforce/GQUIC_Protocol_Analyzer#12); contains those same commits
  as a base, including those by @mmguero and @ckreibich
- Rename deprecated (now removed) "bro" references to "zeek"
- Fixed various issues in .cc and .pac files for namespaces, renamed
  types, intrusive pointers, include file locations, etc.
- Regenerate test output with btest so that it's compatible with v4.0.x and v4.1.x
