### PR TITLE
Fix warning about out-of-scope variable GQUIC::cable_hash

### DIFF
--- a/scripts/Salesforce/GQUIC/main.zeek
+++ b/scripts/Salesforce/GQUIC/main.zeek
@@ -47,6 +47,7 @@ event gquic_hello(c: connection, is_orig: bool, hdr: GQUIC::PublicHeader, HeIn: 
 	#Tag grabber
 	local i = 0;
 	local fingerprint = "";
+	local cable_hash = "";
 	while ( i < (HeIn$tag) )
 		{
 		if (i == 0) {
@@ -68,10 +69,7 @@ event gquic_hello(c: connection, is_orig: bool, hdr: GQUIC::PublicHeader, HeIn: 
 		++i;
 		}
 	if (hdr?$version)
-		{
-		local version_string = fmt("%s", hdr$version);
-		local cable_hash = (version_string + "," + fingerprint); 
-		}
+		cable_hash = (fmt("%s", hdr$version) + "," + fingerprint);
 	else
 		cable_hash=("," + fingerprint);
 	local info: Info;


### PR DESCRIPTION
The string `cable_hash` is used in `main.zeek` outside of the scope of its `local` declaration.

found/fixed/tested with Zeek v5.0.0 in docker, Debian 11 x86_64

Before this fix:

```
 zeek -NN local 2>&1 | grep -i quic
warning in /opt/zeek/share/zeek/site/packages/./GQUIC_Protocol_Analyzer/./main.zeek, line 76: use of out-of-scope local GQUIC::cable_hash deprecated; move declaration to outer scope
Salesforce::GQUIC - Google QUIC (GQUIC) protocol analyzer for Q039-Q046 (dynamic, version 1.0.0)
    [Analyzer] GQUIC (ANALYZER_GQUIC, enabled)
    [Event] gquic_packet
    [Event] gquic_client_version
    [Event] gquic_hello
    [Event] gquic_rej
    [Constant] GQUIC::skip_after_confirm
    [Type] GQUIC::HelloInfo
    [Type] GQUIC::PublicHeader
    [Type] GQUIC::RejInfo
```

After the fix:

```
> zeek -NN local 2>&1 | grep -i quic
Salesforce::GQUIC - Google QUIC (GQUIC) protocol analyzer for Q039-Q046 (dynamic, version 1.0.0)
    [Analyzer] GQUIC (ANALYZER_GQUIC, enabled)
    [Event] gquic_packet
    [Event] gquic_client_version
    [Event] gquic_hello
    [Event] gquic_rej
    [Constant] GQUIC::skip_after_confirm
    [Type] GQUIC::HelloInfo
    [Type] GQUIC::PublicHeader
    [Type] GQUIC::RejInfo
```

Signed-off-by: Seth Grover <mero.mero.guero@gmail.com>