### PR TITLE
ProtocolViolation() is replaced by AnalyzerViolation() in v5.1

### DIFF
--- a/src/GQUIC.cc
+++ b/src/GQUIC.cc
@@ -47,6 +47,10 @@ void GQUIC_Analyzer::DeliverPacket(int len, const u_char* data, bool orig,
 		}
 	catch ( const binpac::Exception& e )
 		{
+#if ZEEK_VERSION_NUMBER >= 40100
 		ProtocolViolation(zeek::util::fmt("Binpac exception: %s", e.c_msg()));
+#else
+                AnalyzerViolation(zeek::util::fmt("Binpac exception: %s", e.c_msg()));
+#endif
 		}
 	}


### PR DESCRIPTION
AnalyzerViolation() should be available as far back as v4.1