### PR TITLE
Replace removed ProtocolConfirmation and ProtocolViolation calls

### DIFF
--- a/src/GQUIC.cc
+++ b/src/GQUIC.cc
@@ -47,10 +47,6 @@ void GQUIC_Analyzer::DeliverPacket(int len, const u_char* data, bool orig,
 		}
 	catch ( const binpac::Exception& e )
 		{
-#if ZEEK_VERSION_NUMBER >= 40100
-		ProtocolViolation(zeek::util::fmt("Binpac exception: %s", e.c_msg()));
-#else
-                AnalyzerViolation(zeek::util::fmt("Binpac exception: %s", e.c_msg()));
-#endif
+			AnalyzerViolation(zeek::util::fmt("Binpac exception: %s", e.c_msg()));
 		}
 	}

--- a/src/GQUIC.h
+++ b/src/GQUIC.h
@@ -9,11 +9,7 @@
 #ifndef ANALYZER_PROTOCOL_GQUIC_GQUIC_H
 #define ANALYZER_PROTOCOL_GQUIC_GQUIC_H
 
-#if ZEEK_VERSION_NUMBER >= 40100
 #include <zeek/packet_analysis/protocol/udp/UDPSessionAdapter.h>
-#else
-#include <zeek/analyzer/protocol/udp/UDP.h>
-#endif
 #include <zeek/analyzer/protocol/pia/PIA.h>
 
 namespace binpac  {

--- a/src/gquic-analyzer.pac
+++ b/src/gquic-analyzer.pac
@@ -27,7 +27,7 @@ refine connection GQUIC_Conn += {
 		// Add the gquic string to conn.log
 		void confirm()
 			{
-			zeek_analyzer()->ProtocolConfirmation();
+			zeek_analyzer()->AnalyzerConfirmation();
 
 			if ( zeek::BifConst::GQUIC::skip_after_confirm )
 				zeek_analyzer()->SetSkip(true);
@@ -37,7 +37,7 @@ refine connection GQUIC_Conn += {
 			{
 			if ( version_bytes[0] != 'Q' )
 				{
-				zeek_analyzer()->ProtocolViolation("invalid GQUIC Version",
+				zeek_analyzer()->AnalyzerViolation("invalid GQUIC Version",
 				    reinterpret_cast<const char*>(version_bytes), 4);
 				return 0;
 				}
@@ -46,7 +46,7 @@ refine connection GQUIC_Conn += {
 				{
 				if ( ! isdigit(version_bytes[i]) )
 					{
-					zeek_analyzer()->ProtocolViolation(
+					zeek_analyzer()->AnalyzerViolation(
 					    "invalid GQUIC Version",
 				        reinterpret_cast<const char*>(version_bytes), 4);
 					return 0;


### PR DESCRIPTION
Replace ProtocolConfirmation and ProtocolViolation with AnalyzerConfirmation and AnalyzerViolation so the plugin works in modern Zeek installations.

I didn't keep in the backwards-compatibility Zeek version IF directives, as this should work back to zeek 4.2, which is ~2 years old by this point.

I've already signed the CLA.